### PR TITLE
Improve handling of GMusic album names.

### DIFF
--- a/mopidypost.py
+++ b/mopidypost.py
@@ -197,7 +197,21 @@ class Mopidy(object):
     def get_gmusic_albums(self):
         p = self.browse('gmusic:album')
         p = {e['name']: e for e in p if e['type'] == 'directory'}
-        return {e.split(' - ')[1]: p[e] for e in p}
+        result = {}
+        for artist_and_album, entry in p.items():
+            try:
+                split_entries = artist_and_album.split(' - ')
+                if len(split_entries) > 1:
+                    album_name = split_entries[-1]
+                    result[album_name] = entry
+                else:
+                    LOG.warning('Could not identify album for GMusic album entry: %s' % artist_and_album)
+                    pass
+            except:
+                LOG.warning('Ignoring unparseable GMusic album entry: %s' % artist_and_album)
+                pass
+
+        return result
 
     def get_gmusic_artists(self):
         p = self.browse('gmusic:artist')


### PR DESCRIPTION
This fixes the skill crashing when encountering weird album names in GMusic responses from Mopidy.

Open items:

1. Unit tests. Do all tests go in `test/__init__.py` or should I make a separate test file? Also, what unit test framework?
2. There is an opportunity to further improve the handling of album names here. What if an artist has a ` - ` in their name? That will produce weird results. I imagine it would be very uncommon, but still possible. A suggestion would be to probably take the last entry in the split array, rather than always the second (included in this PR).